### PR TITLE
Create timers from script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "GodotUtils"]
+	path = GodotUtils
+	url = https://github.com/Valks-Games/GodotUtils

--- a/SharpGame.csproj
+++ b/SharpGame.csproj
@@ -3,4 +3,9 @@
     <TargetFramework>net6.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ENet-CSharp" Version="2.4.8" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+  </ItemGroup>
 </Project>

--- a/scenes/projectile.tscn
+++ b/scenes/projectile.tscn
@@ -24,14 +24,13 @@ fill_to = Vector2(1, 0.5)
 [sub_resource type="CircleShape2D" id="CircleShape2D_f4mkt"]
 radius = 2.0
 
-[node name="Projectile" type="CharacterBody2D" node_paths=PackedStringArray("DamageComponent", "HitboxComponent", "Timer")]
+[node name="Projectile" type="CharacterBody2D" node_paths=PackedStringArray("DamageComponent", "HitboxComponent")]
 collision_layer = 3
 collision_mask = 3
 motion_mode = 1
 script = ExtResource("1_28v6d")
 DamageComponent = NodePath("DamageComponent")
 HitboxComponent = NodePath("HitboxComponent")
-Timer = NodePath("Timer")
 
 [node name="DamageComponent" type="Node" parent="."]
 script = ExtResource("1_xdfwa")
@@ -54,8 +53,3 @@ texture = SubResource("GradientTexture2D_j4ss6")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_f4mkt")
-
-[node name="Timer" type="Timer" parent="."]
-process_callback = 0
-wait_time = 3.0
-autostart = true

--- a/scenes/world.tscn
+++ b/scenes/world.tscn
@@ -12,14 +12,9 @@
 script = ExtResource("1_v6hlk")
 _spawner = NodePath("Spawner")
 
-[node name="Spawner" type="Node2D" parent="." node_paths=PackedStringArray("_player", "_timer")]
+[node name="Spawner" type="Node2D" parent="." node_paths=PackedStringArray("_player")]
 script = ExtResource("2_lvh7q")
 _player = NodePath("../Player")
-_timer = NodePath("Timer")
-
-[node name="Timer" type="Timer" parent="Spawner"]
-process_callback = 0
-wait_time = 2.0
 
 [node name="TileMap" type="TileMap" parent="."]
 texture_filter = 2
@@ -39,6 +34,7 @@ layer_1/tile_data = PackedInt32Array(196600, 917504, 0, 65557, 983040, 0, 131093
 script = ExtResource("5_ch4fl")
 
 [node name="Player" parent="." instance=ExtResource("2_26r7e")]
+position = Vector2(230, 34)
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
 limit_left = -624

--- a/scripts/Projectile.cs
+++ b/scripts/Projectile.cs
@@ -8,8 +8,7 @@ public partial class Projectile : CharacterBody2D
     [Export]
     public HitboxComponent HitboxComponent;
 
-    [Export]
-    public Timer Timer;
+    GTimer _timer;
 
     public override void _Ready()
     {
@@ -23,7 +22,9 @@ public partial class Projectile : CharacterBody2D
             QueueFree();
         };
 
-        Timer.Timeout += () => QueueFree();
+        _timer = new GTimer(this, 3000);
+        _timer.Start();
+        _timer.Finished += () => QueueFree();
     }
 
     public override void _PhysicsProcess(double delta)

--- a/scripts/Spawner.cs
+++ b/scripts/Spawner.cs
@@ -1,3 +1,5 @@
+using GodotUtils;
+
 namespace SharpGame;
 
 public partial class Spawner : Node2D
@@ -8,8 +10,7 @@ public partial class Spawner : Node2D
     [Export]
     Player _player = null;
 
-    [Export]
-    Timer _timer = null;
+    GTimer _timer;
 
     PhysicsDirectSpaceState2D _spaceState = null;
     PackedScene _enemyScene = (PackedScene)GD.Load("res://scenes/flyer.tscn");
@@ -18,7 +19,11 @@ public partial class Spawner : Node2D
     Godot.Collections.Array<PackedScene> _queue = new();
     Godot.Collections.Array<Node2D> _entities = new();
 
-    public override void _Ready() => _timer.Timeout += OnTimerTimeout;
+    public override void _Ready()
+    {
+        _timer = new GTimer(this, 2000);
+        _timer.Finished += OnTimerTimeout;
+    }
 
     public override void _PhysicsProcess(double delta)
     {

--- a/scripts/Spawner.cs
+++ b/scripts/Spawner.cs
@@ -1,5 +1,3 @@
-using GodotUtils;
-
 namespace SharpGame;
 
 public partial class Spawner : Node2D
@@ -21,7 +19,7 @@ public partial class Spawner : Node2D
 
     public override void _Ready()
     {
-        _timer = new GTimer(this, 2000);
+        _timer = new GTimer(this, 2000) { Loop = true };
         _timer.Finished += OnTimerTimeout;
     }
 

--- a/scripts/singletons/Game.cs
+++ b/scripts/singletons/Game.cs
@@ -1,4 +1,5 @@
 global using Godot;
+global using GodotUtils;
 global using System;
 global using System.Linq;
 


### PR DESCRIPTION
This PR adds a new submodule [GodotUtils](https://github.com/ValksGodotTools/GodotUtils) to make use of its GTimer helper class to define timers through script rather than through the editor. This saves time when creating timers on the fly when programming rather than following the somewhat long to setup component design pattern. 